### PR TITLE
feat(user): add scheduled user node

### DIFF
--- a/src/agentrylab/cli/app.py
+++ b/src/agentrylab/cli/app.py
@@ -260,6 +260,21 @@ def list_threads_cmd(
         typer.echo(f"{tid}\t{dt}")
 
 
+@app.command("say")
+def say_cmd(
+    preset: Path = typer.Argument(..., exists=True, readable=True, help="Path to YAML preset"),
+    thread_id: str = typer.Argument(..., help="Thread id to post into"),
+    message: str = typer.Argument(..., help="User message to append"),
+    user_id: str = typer.Option("user", help="Logical user id (default: 'user')"),
+) -> None:
+    """Append a user message into a thread's history (and transcript)."""
+    _load_env()
+    cfg = load_config(str(preset))
+    lab = init_lab(cfg, thread_id=thread_id, resume=True)
+    lab.post_user_message(message, user_id=user_id)
+    typer.echo(f"Appended user message to thread '{thread_id}' as {user_id}.")
+
+
 def main() -> None:  # pragma: no cover
     app()
 

--- a/src/agentrylab/config/loader.py
+++ b/src/agentrylab/config/loader.py
@@ -65,13 +65,13 @@ class Tool(BaseModel):
 
 
 # ------------------------------- Nodes -------------------------------
-Role = Literal["agent", "advisor", "moderator", "summarizer"]
+Role = Literal["agent", "advisor", "moderator", "summarizer", "user"]
 
 
 class BaseNode(BaseModel):
     id: str
     role: Role
-    provider: str
+    provider: Optional[str] = None
     display_name: Optional[str] = None
     description: Optional[str] = None
     system_prompt: Optional[str] = None
@@ -144,7 +144,7 @@ class Preset(BaseModel):
     tools: List[Tool] = Field(default_factory=list)
 
     # Nodes
-    agents: List[Agent] = Field(default_factory=list)
+    agents: List[Union[Agent, User]] = Field(default_factory=list)
     advisors: List[Advisor] = Field(default_factory=list)
     moderator: Optional[Moderator] = None
     summarizer: Optional[Summarizer] = None
@@ -267,3 +267,7 @@ def load_config(path_or_dict: Union[str, Path, dict]) -> Preset:
         raw = _normalize_nodes(raw)
 
     return Preset.model_validate(raw)
+# ------------------------------- Users -------------------------------
+class User(BaseNode):
+    role: Literal["user"] = "user"
+

--- a/src/agentrylab/presets/user_in_loop.yaml
+++ b/src/agentrylab/presets/user_in_loop.yaml
@@ -1,0 +1,33 @@
+version: 1
+id: user-in-loop
+name: User In Loop
+objective: ${OBJECTIVE:Chat with a human in the loop}
+
+providers:
+  - id: llama3
+    impl: agentrylab.runtime.providers.ollama.OllamaProvider
+    model: llama3:latest
+    timeout: 8
+
+agents:
+  - id: user:human
+    role: user
+  - id: bot
+    role: agent
+    provider: llama3
+    system_prompt: "You are a helpful bot responding to the user."
+
+summarizer:
+  id: recap
+  role: summarizer
+  provider: llama3
+  system_prompt: "Summarize the conversation so far in 3-5 sentences."
+  max_summary_chars: 400
+
+runtime:
+  scheduler:
+    impl: agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler
+    params:
+      order: [user:human, bot, recap]
+  context_defaults:
+    pin_objective: true

--- a/src/agentrylab/runtime/engine.py
+++ b/src/agentrylab/runtime/engine.py
@@ -110,6 +110,8 @@ class Engine:
     # ------------------------------------------------------------------
     def _apply_output(self, agent_id: str, out: NodeOutput, *, duration_ms: float | None = None) -> None:
         """Apply a node's output to state and persistence."""
+        if out.role == "user" and (not out.content or (isinstance(out.content, str) and not out.content.strip())):
+            return
         # Update state/history first so later consumers can see it
         if hasattr(self.state, "append_message"):
             try:

--- a/src/agentrylab/runtime/nodes/base.py
+++ b/src/agentrylab/runtime/nodes/base.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 # ----------------------------- Types ---------------------------------------
-Role = Literal["agent", "moderator", "summarizer", "advisor"]
+Role = Literal["agent", "moderator", "summarizer", "advisor", "user"]
 
 class NodeAction(TypedDict, total=False):
     """Control signals emitted by nodes (primarily Moderator)."""

--- a/src/agentrylab/runtime/nodes/factory.py
+++ b/src/agentrylab/runtime/nodes/factory.py
@@ -6,16 +6,18 @@ from .agent import AgentNode
 from .moderator import ModeratorNode
 from .summarizer import SummarizerNode
 from .advisor import AdvisorNode
+from .user import UserNode
 
 ROLE_TO_NODE: Dict[str, Type[NodeBase]] = {
     "agent": AgentNode,
     "moderator": ModeratorNode,
     "summarizer": SummarizerNode,
     "advisor": AdvisorNode,
+    "user": UserNode,
 }
 
 # Type alias for returned node
-NodeType = Union[AgentNode, ModeratorNode, SummarizerNode, AdvisorNode]
+NodeType = Union[AgentNode, ModeratorNode, SummarizerNode, AdvisorNode, UserNode]
 
 def make_node(cfg: Any, provider: Any, tools: Dict[str, Any]) -> NodeType:
     """

--- a/src/agentrylab/runtime/nodes/user.py
+++ b/src/agentrylab/runtime/nodes/user.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .base import NodeBase, NodeOutput
+
+
+class UserNode(NodeBase):
+    """Scheduled user turn that emits the next queued user message."""
+
+    role_name = "user"
+
+    def __init__(self, cfg: Any, provider: Any = None, tools: Dict[str, Any] | None = None):
+        # User nodes don't call a provider; store references for API parity
+        self.cfg = cfg
+        self.provider = provider
+        self.tools = tools or {}
+
+    def __call__(self, state: Any) -> NodeOutput:  # type: ignore[override]
+        msg = None
+        if hasattr(state, "pop_user_input"):
+            try:
+                msg = state.pop_user_input(getattr(self.cfg, "id", "user"))
+            except Exception:
+                msg = None
+        if msg is None:
+            msg = ""
+        return NodeOutput(role="user", content=str(msg))
+
+    # Unused abstract hooks -------------------------------------------------
+    def build_messages(self, state: Any):  # pragma: no cover - not used
+        return []
+
+    def postprocess(self, raw: Dict[str, Any], state: Any):  # pragma: no cover - not used
+        raise NotImplementedError
+
+    def validate(self, out: NodeOutput, state: Any) -> None:  # pragma: no cover - not used
+        return

--- a/src/agentrylab/runtime/state.py
+++ b/src/agentrylab/runtime/state.py
@@ -65,6 +65,9 @@ class State:
         # Per-tool counts for the current iteration
         self._tool_calls_iter_by_id: Dict[str, int] = {}
 
+        # User input queues (per user id)
+        self._user_inputs: Dict[str, List[str]] = {}
+
     # ------------------------------------------------------------------
     # Message building for providers
     # ------------------------------------------------------------------
@@ -243,6 +246,22 @@ class State:
         For MVP, we just update the running_summary; the engine already persisted the original.
         """
         self.running_summary = content
+
+    # ------------------------------------------------------------------
+    # User input queue (used by user-injection features and UserNode)
+    # ------------------------------------------------------------------
+    def enqueue_user_message(self, user_id: str, content: str) -> None:
+        """Enqueue a user message to be consumed by user turns or injected immediately."""
+        self._user_inputs.setdefault(user_id, []).append(str(content))
+
+    def has_user_input(self, user_id: str) -> bool:
+        return bool(self._user_inputs.get(user_id))
+
+    def pop_user_input(self, user_id: str) -> Optional[str]:
+        queue = self._user_inputs.get(user_id) or []
+        if queue:
+            return queue.pop(0)
+        return None
 
     # ------------------------------------------------------------------
     # Budgets: per-run / per-iteration (global and per-tool-id)

--- a/tests/test_user_injection.py
+++ b/tests/test_user_injection.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from agentrylab import init
+
+
+def _preset_dict():
+    return {
+        "id": "user-inject",
+        "providers": [
+            {"id": "p1", "impl": "tests.fake_impls.TestProvider", "model": "test"},
+        ],
+        "agents": [
+            {"id": "talker", "role": "agent", "provider": "p1", "system_prompt": "You are the agent."}
+        ],
+        "runtime": {
+            "scheduler": {
+                "impl": "agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler",
+                "params": {"order": ["talker"]},
+            }
+        },
+    }
+
+
+def test_post_user_message_appears_in_history_and_provider_sees_it(tmp_path):
+    lab = init(_preset_dict(), experiment_id="user-inject-1", resume=False)
+    # Post a user message
+    lab.post_user_message("Hello agents!", user_id="user")
+
+    # Verify it's in in-memory history before running
+    assert any(e.get("role") == "user" and "Hello agents!" in str(e.get("content")) for e in lab.state.history)
+
+    # Run one round; provider should now see the user message in messages
+    lab.run(rounds=1)
+    provider = lab.providers["p1"]
+    msgs = getattr(provider, "last_messages", [])
+    assert any(m.get("role") == "user" and "Hello agents!" in str(m.get("content")) for m in msgs)

--- a/tests/test_user_node.py
+++ b/tests/test_user_node.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import uuid
+
+from agentrylab import init
+
+
+def preset_dict():
+    return {
+        "id": "user-node-test",
+        "providers": [
+            {"id": "p1", "impl": "tests.fake_impls.TestProvider", "model": "test"},
+        ],
+        "agents": [
+            {"id": "user:alice", "role": "user"},
+            {
+                "id": "talker",
+                "role": "agent",
+                "provider": "p1",
+                "system_prompt": "Reply to the user",
+            },
+        ],
+        "runtime": {
+            "scheduler": {
+                "impl": "agentrylab.runtime.scheduler.every_n.EveryNScheduler",
+                "params": {"schedule": {"user:alice": 1, "talker": 1}},
+            }
+        },
+    }
+
+
+def test_user_node_consumes_queue_and_skips_when_empty():
+    tid = f"user-node-{uuid.uuid4().hex[:6]}"
+    lab = init(preset_dict(), experiment_id=tid, resume=False)
+    # enqueue message for first turn only
+    lab.post_user_message("hi there", user_id="user:alice", immediate=False, persist=False)
+    # first iteration processes user + agent
+    lab.run(rounds=1)
+    first_msgs = lab.providers["p1"].last_messages
+    assert any(m.get("role") == "user" for m in first_msgs)
+    # second iteration: no user message queued -> skipped
+    lab.run(rounds=1)
+    tail = lab.store.read_transcript(tid, limit=10)
+    roles = [e["role"] for e in tail]
+    assert roles == ["user", "agent", "agent"]


### PR DESCRIPTION
## Summary
- add `UserNode` so user messages can be scheduled like any other node
- allow preset role `user` and queue user messages via `Lab.post_user_message`
- skip empty user turns when no input is queued
- provide `user_in_loop.yaml` example preset
- cover queued user turns with tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb1e0b3cb8832ab862af0bc337c281