### PR TITLE
feat(user-in-the-loop): Scheduled UserNode + schema + engine tweak + docs

### DIFF
--- a/src/agentrylab/cli/app.py
+++ b/src/agentrylab/cli/app.py
@@ -260,6 +260,21 @@ def list_threads_cmd(
         typer.echo(f"{tid}\t{dt}")
 
 
+@app.command("say")
+def say_cmd(
+    preset: Path = typer.Argument(..., exists=True, readable=True, help="Path to YAML preset"),
+    thread_id: str = typer.Argument(..., help="Thread id to post into"),
+    message: str = typer.Argument(..., help="User message to append"),
+    user_id: str = typer.Option("user", help="Logical user id (default: 'user')"),
+) -> None:
+    """Append a user message into a thread's history (and transcript)."""
+    _load_env()
+    cfg = load_config(str(preset))
+    lab = init_lab(cfg, thread_id=thread_id, resume=True)
+    lab.post_user_message(message, user_id=user_id)
+    typer.echo(f"Appended user message to thread '{thread_id}' as {user_id}.")
+
+
 def main() -> None:  # pragma: no cover
     app()
 

--- a/src/agentrylab/config/loader.py
+++ b/src/agentrylab/config/loader.py
@@ -65,7 +65,7 @@ class Tool(BaseModel):
 
 
 # ------------------------------- Nodes -------------------------------
-Role = Literal["agent", "advisor", "moderator", "summarizer"]
+Role = Literal["agent", "advisor", "moderator", "summarizer", "user"]
 
 
 class BaseNode(BaseModel):
@@ -100,6 +100,10 @@ class Moderator(BaseNode):
 class Summarizer(BaseNode):
     role: Literal["summarizer"] = "summarizer"
     max_summary_chars: Optional[int] = None
+
+
+class User(BaseNode):
+    role: Literal["user"] = "user"
 
 
 # ----------------------------- Scheduler -----------------------------
@@ -144,7 +148,7 @@ class Preset(BaseModel):
     tools: List[Tool] = Field(default_factory=list)
 
     # Nodes
-    agents: List[Agent] = Field(default_factory=list)
+    agents: List[Agent | User] = Field(default_factory=list)
     advisors: List[Advisor] = Field(default_factory=list)
     moderator: Optional[Moderator] = None
     summarizer: Optional[Summarizer] = None

--- a/src/agentrylab/docs/ARCHITECTURE.md
+++ b/src/agentrylab/docs/ARCHITECTURE.md
@@ -70,6 +70,8 @@ Nodes 🎭
     /citations) and may signal `STOP` or `STEP_BACK` to the engine.
   - Summarizer: consolidates progress into concise summaries.
   - Advisor: non‑blocking reviewer emitting commentary.
+  - User: scheduled user turns that inject queued user messages into the transcript/history.
+    - Note: UserNode never calls providers; the `provider` field in presets is accepted but ignored.
 - Outputs: a `NodeOutput` with `role`, `content`, optional `metadata` and
   optional `actions` (control signals consumed by the engine).
 
@@ -95,6 +97,9 @@ State 🧠
     same tick.
   - Minima are advisory (not enforced at call time).
   - `can_call_tool()` and `note_tool_call()` implement the policy.
+- User input queues
+  - `enqueue_user_message(user_id, content)`, `has_user_input`, `pop_user_input`
+  - Used by the UserNode and by API/CLI injection (Option B baseline) to feed user lines.
 - Message contracts: validates agent outputs (e.g., require citations) according
   to `runtime.message_contract`. Violations produce errors recorded in the
   transcript and fail the node turn.
@@ -110,6 +115,8 @@ Engine 🚂
   5. Increment `iter` and save a checkpoint.
 - Transcript entries include timestamps, iter index, agent id/role, content,
   metadata, actions, and latency.
+- Empty user turns: the engine skips appending empty user outputs to the transcript
+  to avoid noise when no message is queued for a scheduled user node.
 
 Persistence (Store) 📜💾
 - Transcript: append‑only JSONL, one file per thread id. Reading supports last‑N

--- a/src/agentrylab/docs/CLI.md
+++ b/src/agentrylab/docs/CLI.md
@@ -10,6 +10,13 @@ Commands 🧭
   - Usage: `agentrylab status <preset.yaml> <thread-id>`
 - validate: lint a preset file and print advisory warnings
   - Usage: `agentrylab validate <preset.yaml>`
+- say: append a user message into a thread (user-in-the-loop)
+  - Usage: `agentrylab say <preset.yaml> <thread-id> "message" [--user-id USER]`
+  - Example: `agentrylab say src/agentrylab/presets/user_in_the_loop.yaml demo "Hello agents!"`
+ - ls: list known threads (from the checkpoint store)
+   - Usage: `agentrylab ls <preset.yaml>`
+ - reset: delete checkpoint (and optionally transcript) for a thread
+   - Usage: `agentrylab reset <preset.yaml> <thread-id> [--delete-transcript]`
 
 Run options ⚙️
 - --max-iters INT: Number of engine ticks to execute (default: 8)
@@ -27,6 +34,9 @@ Examples 💡
   - `agentrylab run src/agentrylab/presets/debates.yaml --max-iters 1 --thread-id demo --no-resume`
 - Inspect checkpoint status
   - `agentrylab status src/agentrylab/presets/debates.yaml demo`
+- Post a user message and run one tick
+  - `agentrylab say src/agentrylab/presets/user_in_the_loop.yaml demo "Hi team!"`
+  - `agentrylab run src/agentrylab/presets/user_in_the_loop.yaml --thread-id demo --resume --max-iters 1`
 
 Environment and .env 🔑
 - The CLI loads environment variables from `.env` (if present) via `python-dotenv`
@@ -51,6 +61,13 @@ Persistence 📜💾
   - The engine saves a snapshot after each tick.
   - With `--resume` (default), the CLI merges any saved snapshot into the
     in-memory state before running (best-effort; only dict snapshots are merged).
+
+Clean all outputs 🧹
+- Quick way: delete the outputs root (default location):
+  - `rm -rf outputs/`  (this removes all transcripts and the checkpoints DB)
+- Per-thread loop (safer): reset each listed thread and delete transcripts:
+  - `for tid in $(agentrylab ls src/agentrylab/presets/solo_chat.yaml | awk '{print $1}'); do agentrylab reset src/agentrylab/presets/solo_chat.yaml "$tid" --delete-transcript; done`
+  - Replace the preset path with the one you’re using; `ls` reads from the checkpoint DB to enumerate threads.
 
 What to expect in transcript JSONL 🧾
 - Each line is a JSON object with fields like:

--- a/src/agentrylab/docs/PRESET_TIPS.md
+++ b/src/agentrylab/docs/PRESET_TIPS.md
@@ -50,3 +50,14 @@ Examples 📦
 - Drifty Thoughts: three thinkers every turn; gentle advisor every 2; summarizer every 3 & on last
 - Research Collaboration: two scientists every turn; style coach/moderator every 2; summarizer every 2 & on last (moderator uses JSON exemplar)
 
+User in the Loop 👤
+- Schedule a `user` role to place human turns exactly where you want.
+  - Round‑Robin example: `order: ["user:alice", "assistant"]`
+  - Every‑N example: `{ "user:alice": 1, "assistant": 1, "summarizer": { every_n: 3, run_on_last: true } }`
+- Post messages via CLI/API; they are consumed on the next scheduled user turn.
+  - CLI: `agentrylab say <preset.yaml> <thread> "Hi team!" --user-id user:alice`
+  - Python: `lab.post_user_message("Hi team!", user_id="user:alice")`
+- Tips:
+  - Use IDs like `user:alice`, `user:bob` to target multiple distinct users.
+  - The `provider` field on `user` nodes is ignored by the runtime and exists only to fit the schema.
+  - Empty user turns are skipped in transcript if no message is queued.

--- a/src/agentrylab/docs/RECIPES.md
+++ b/src/agentrylab/docs/RECIPES.md
@@ -123,3 +123,12 @@ for ev in lab.history(limit=20):
 # Or read directly from the store
 rows = lab.store.read_transcript("inspect-1", limit=100)
 ```
+
+User-in-the-loop: post and run 👤
+```
+from agentrylab import init
+
+lab = init("src/agentrylab/presets/user_in_the_loop.yaml", experiment_id="chat-1")
+lab.post_user_message("Hello from Alice!", user_id="user:alice")
+lab.run(rounds=1)  # scheduled user then assistant
+```

--- a/src/agentrylab/presets/solo_chat_user.yaml
+++ b/src/agentrylab/presets/solo_chat_user.yaml
@@ -1,0 +1,57 @@
+#########################
+# Solo Chat (User-in-the-Loop) preset
+# Single assistant with a scheduled user turn before each response.
+# Post messages via CLI/API to let a human steer the chat.
+#   CLI: agentrylab say src/agentrylab/presets/solo_chat_user.yaml demo "Hello!" --user-id user:you
+#   Run: agentrylab run src/agentrylab/presets/solo_chat_user.yaml --thread-id demo --resume --max-iters 1
+#########################
+
+version: "1.0.0"
+id: solo_chat_user
+name: Solo Chat (User Turn)
+description: A friendly assistant that responds after a scheduled user turn each round.
+
+objective: ${CHAT_TOPIC:Say hello and ask a short question to the assistant.}
+
+runtime:
+  trace: { enabled: true }
+  scheduler:
+    impl: agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler
+    params:
+      order: ["user:you", "assistant"]
+  message_contract:
+    require_metadata: false
+  context_defaults:
+    pin_objective: true
+  max_rounds: 10
+
+providers:
+  - id: ollama_llama3
+    impl: agentrylab.runtime.providers.ollama.OllamaProvider
+    model: "llama3:latest"
+    base_url: "http://localhost:11434"
+    temperature: 0.7
+
+tools: []
+advisors: []
+
+agents:
+  - id: "user:you"
+    role: user
+    provider: ollama_llama3  # ignored by runtime for user nodes
+    description: Scheduled user node; consumes queued human messages
+
+  - id: assistant
+    role: agent
+    display_name: "Assistant"
+    description: Friendly conversational assistant
+    provider: ollama_llama3
+    tools: []
+    context:
+      max_messages: 5
+      pin_objective: true
+      running_summary: false
+    system_prompt: |
+      You are a friendly and helpful assistant. React concisely (2–4 lines) to the user's last message.
+      Be conversational and supportive. No questions back; just a self-contained reply unless the user asks.
+

--- a/src/agentrylab/presets/user_in_the_loop.yaml
+++ b/src/agentrylab/presets/user_in_the_loop.yaml
@@ -1,0 +1,49 @@
+#########################
+# User-in-the-Loop preset
+# Demonstrates a scheduled user node placed before an agent.
+# Use CLI to append messages: `agentrylab say <preset.yaml> <thread> "Hi agents!"`
+#########################
+
+version: "1.0.0"
+id: user_in_the_loop
+name: User in the Loop
+description: A scheduled user node feeds messages into the conversation before the agent.
+
+objective: ${TOPIC:Say hello and provide a short hint for the agent.}
+
+runtime:
+  max_rounds: 4
+  trace: { enabled: true }
+  scheduler:
+    impl: agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler
+    params:
+      order: ["user:alice", "assistant"]
+  message_contract:
+    require_metadata: false
+  context_defaults:
+    pin_objective: true
+
+providers:
+  - id: ollama_llama3
+    impl: agentrylab.runtime.providers.ollama.OllamaProvider
+    model: "llama3:latest"
+    base_url: "http://localhost:11434"
+    timeout: 8
+
+tools: []
+advisors: []
+
+agents:
+  - id: "user:alice"
+    role: user
+    provider: ollama_llama3
+    description: A scheduled user node emitting queued messages
+
+  - id: assistant
+    role: agent
+    provider: ollama_llama3
+    description: Friendly agent that reacts to user input
+    system_prompt: |
+      You are a friendly assistant. React concisely (2–4 lines) to the user's last message.
+      Do not ask the user to type/answer; write a self-contained reply.
+

--- a/src/agentrylab/runtime/engine.py
+++ b/src/agentrylab/runtime/engine.py
@@ -110,6 +110,11 @@ class Engine:
     # ------------------------------------------------------------------
     def _apply_output(self, agent_id: str, out: NodeOutput, *, duration_ms: float | None = None) -> None:
         """Apply a node's output to state and persistence."""
+        # Skip empty user outputs to avoid transcript noise
+        if out.role == "user":
+            content = out.content if getattr(out, "content", None) is not None else ""
+            if not isinstance(content, str) or not content.strip():
+                return
         # Update state/history first so later consumers can see it
         if hasattr(self.state, "append_message"):
             try:

--- a/src/agentrylab/runtime/nodes/factory.py
+++ b/src/agentrylab/runtime/nodes/factory.py
@@ -6,12 +6,14 @@ from .agent import AgentNode
 from .moderator import ModeratorNode
 from .summarizer import SummarizerNode
 from .advisor import AdvisorNode
+from .user import UserNode
 
 ROLE_TO_NODE: Dict[str, Type[NodeBase]] = {
     "agent": AgentNode,
     "moderator": ModeratorNode,
     "summarizer": SummarizerNode,
     "advisor": AdvisorNode,
+    "user": UserNode,
 }
 
 # Type alias for returned node

--- a/src/agentrylab/runtime/nodes/user.py
+++ b/src/agentrylab/runtime/nodes/user.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .base import NodeBase, NodeOutput
+from agentrylab.runtime.providers.base import Message
+
+
+class UserNode(NodeBase):
+    """Scheduled user node that emits the next queued user message.
+
+    This node does not call any provider. It pops the next message from the
+    state's user input queue for this node's id (cfg.id). If no message is
+    available, it returns an empty content; the Engine will skip empty user
+    outputs to avoid transcript noise.
+    """
+
+    role_name = "user"
+
+    def build_messages(self, state: Any) -> List[Message]:
+        # Users do not talk to providers; no messages needed.
+        return []
+
+    def postprocess(self, raw: Dict[str, Any], state: Any) -> NodeOutput:  # pragma: no cover
+        # Not used; we never call providers for UserNode.
+        return NodeOutput(role=self.role_name, content="")
+
+    def validate(self, out: NodeOutput, state: Any) -> None:  # pragma: no cover
+        return
+
+    def __call__(self, state: Any) -> NodeOutput:
+        user_id = getattr(self.cfg, "id", "user")
+        try:
+            content = state.pop_user_input(user_id)  # type: ignore[attr-defined]
+        except Exception:
+            content = None
+        text = content if isinstance(content, str) else ""
+        return NodeOutput(role=self.role_name, content=text)
+

--- a/src/agentrylab/runtime/state.py
+++ b/src/agentrylab/runtime/state.py
@@ -65,6 +65,9 @@ class State:
         # Per-tool counts for the current iteration
         self._tool_calls_iter_by_id: Dict[str, int] = {}
 
+        # User input queues (per user id)
+        self._user_inputs: Dict[str, List[str]] = {}
+
     # ------------------------------------------------------------------
     # Message building for providers
     # ------------------------------------------------------------------
@@ -243,6 +246,22 @@ class State:
         For MVP, we just update the running_summary; the engine already persisted the original.
         """
         self.running_summary = content
+
+    # ------------------------------------------------------------------
+    # User input queue (used by user-injection features and UserNode)
+    # ------------------------------------------------------------------
+    def enqueue_user_message(self, user_id: str, content: str) -> None:
+        """Enqueue a user message to be consumed by user turns or injected immediately."""
+        self._user_inputs.setdefault(user_id, []).append(str(content))
+
+    def has_user_input(self, user_id: str) -> bool:
+        return bool(self._user_inputs.get(user_id))
+
+    def pop_user_input(self, user_id: str) -> Optional[str]:
+        queue = self._user_inputs.get(user_id) or []
+        if queue:
+            return queue.pop(0)
+        return None
 
     # ------------------------------------------------------------------
     # Budgets: per-run / per-iteration (global and per-tool-id)

--- a/tests/test_user_injection.py
+++ b/tests/test_user_injection.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from agentrylab import init
+
+
+def _preset_dict():
+    return {
+        "id": "user-inject",
+        "providers": [
+            {"id": "p1", "impl": "tests.fake_impls.TestProvider", "model": "test"},
+        ],
+        "agents": [
+            {"id": "talker", "role": "agent", "provider": "p1", "system_prompt": "You are the agent."}
+        ],
+        "runtime": {
+            "scheduler": {
+                "impl": "agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler",
+                "params": {"order": ["talker"]},
+            }
+        },
+    }
+
+
+def test_post_user_message_appears_in_history_and_provider_sees_it(tmp_path):
+    lab = init(_preset_dict(), experiment_id="user-inject-1", resume=False)
+    # Post a user message
+    lab.post_user_message("Hello agents!", user_id="user")
+
+    # Verify it's in in-memory history before running
+    assert any(e.get("role") == "user" and "Hello agents!" in str(e.get("content")) for e in lab.state.history)
+
+    # Run one round; provider should now see the user message in messages
+    lab.run(rounds=1)
+    provider = lab.providers["p1"]
+    msgs = getattr(provider, "last_messages", [])
+    assert any(m.get("role") == "user" and "Hello agents!" in str(m.get("content")) for m in msgs)

--- a/tests/test_user_node.py
+++ b/tests/test_user_node.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from agentrylab import init
+
+
+def _preset_with_user_and_agent():
+    return {
+        "id": "user-node-demo",
+        "providers": [
+            {"id": "p1", "impl": "tests.fake_impls.TestProvider", "model": "test"},
+        ],
+        "tools": [
+            {"id": "echo", "impl": "tests.fake_impls.EchoTool"},
+        ],
+        "agents": [
+            {"id": "user:alice", "role": "user", "provider": "p1"},
+            {"id": "talker", "role": "agent", "provider": "p1", "system_prompt": "You are the agent."},
+        ],
+        "runtime": {
+            "scheduler": {
+                "impl": "agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler",
+                "params": {"order": ["user:alice", "talker"]},
+            }
+        },
+    }
+
+
+def _preset_with_user_only():
+    return {
+        "id": "user-only",
+        "providers": [
+            {"id": "p1", "impl": "tests.fake_impls.TestProvider", "model": "test"},
+        ],
+        "agents": [
+            {"id": "user:alice", "role": "user", "provider": "p1"},
+        ],
+        "runtime": {
+            "scheduler": {
+                "impl": "agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler",
+                "params": {"order": ["user:alice"]},
+            }
+        },
+    }
+
+
+def test_user_node_consumes_enqueued_and_precedes_agent(tmp_path):
+    # Arrange: user turn then agent; enqueue a message for the user node
+    lab = init(_preset_with_user_and_agent(), experiment_id="user-node-1", resume=False)
+    lab.state.enqueue_user_message("user:alice", "Hello from Alice!")
+
+    # Act: run one tick (user then agent)
+    lab.run(rounds=1)
+
+    # Assert: transcript order is user then agent, and agent saw the user line
+    rows = lab.store.read_transcript("user-node-1")
+    assert len(rows) >= 2
+    user_ev, agent_ev = rows[-2], rows[-1]
+    assert user_ev.get("role") == "user"
+    assert user_ev.get("agent_id") == "user:alice"
+    assert "Hello from Alice!" in str(user_ev.get("content"))
+    assert agent_ev.get("role") == "agent"
+    # Provider should have seen the user message in composed messages
+    provider = lab.providers["p1"]
+    msgs = getattr(provider, "last_messages", [])
+    assert any(m.get("role") == "user" and "Hello from Alice!" in str(m.get("content")) for m in msgs)
+
+
+def test_empty_user_turn_is_skipped_in_transcript(tmp_path):
+    # Arrange: only a user node is scheduled; no messages queued
+    lab = init(_preset_with_user_only(), experiment_id="user-node-2", resume=False)
+
+    # Act: run one tick; nothing should be appended for the empty user turn
+    lab.run(rounds=1)
+
+    # Assert: transcript has no events (engine skipped empty user output)
+    rows = lab.store.read_transcript("user-node-2")
+    assert rows == [] or all(r.get("role") != "user" for r in rows)
+
+
+def test_user_node_never_calls_provider(tmp_path):
+    # Arrange: only a user node and one queued message
+    lab = init(_preset_with_user_only(), experiment_id="user-node-3", resume=False)
+    lab.state.enqueue_user_message("user:alice", "Ping!")
+
+    # Act: run one tick (only user node executes)
+    lab.run(rounds=1)
+
+    # Assert: user event exists, but provider was not called by the user node
+    rows = lab.store.read_transcript("user-node-3")
+    assert any(r.get("role") == "user" and "Ping!" in str(r.get("content")) for r in rows)
+    provider = lab.providers["p1"]
+    assert not hasattr(provider, "last_messages"), "UserNode should not call provider.chat()"
+
+
+def test_multi_user_targets_and_order(tmp_path):
+    preset = {
+        "id": "multi-user",
+        "providers": [
+            {"id": "p1", "impl": "tests.fake_impls.TestProvider", "model": "test"},
+        ],
+        "agents": [
+            {"id": "user:alice", "role": "user", "provider": "p1"},
+            {"id": "user:bob", "role": "user", "provider": "p1"},
+            {"id": "talker", "role": "agent", "provider": "p1", "system_prompt": "You are the agent."},
+        ],
+        "runtime": {
+            "scheduler": {
+                "impl": "agentrylab.runtime.scheduler.round_robin.RoundRobinScheduler",
+                "params": {"order": ["user:alice", "user:bob", "talker"]},
+            }
+        },
+    }
+
+    lab = init(preset, experiment_id="multi-user-1", resume=False)
+    # Enqueue distinct messages for each user node
+    lab.state.enqueue_user_message("user:alice", "Hi from Alice")
+    lab.state.enqueue_user_message("user:bob", "Hey from Bob")
+
+    lab.run(rounds=1)
+
+    rows = lab.store.read_transcript("multi-user-1")
+    assert len(rows) >= 3
+    u1, u2, agent_ev = rows[-3], rows[-2], rows[-1]
+    assert u1.get("agent_id") == "user:alice" and "Hi from Alice" in str(u1.get("content"))
+    assert u2.get("agent_id") == "user:bob" and "Hey from Bob" in str(u2.get("content"))
+    assert agent_ev.get("agent_id") == "talker" and agent_ev.get("role") == "agent"
+
+    # Agent provider should see both user lines in its composed messages
+    provider = lab.providers["p1"]
+    msgs = getattr(provider, "last_messages", [])
+    got_alice = any(m.get("role") == "user" and "Hi from Alice" in str(m.get("content")) for m in msgs)
+    got_bob = any(m.get("role") == "user" and "Hey from Bob" in str(m.get("content")) for m in msgs)
+    assert got_alice and got_bob

--- a/user_in_the_loop_interactive.py
+++ b/user_in_the_loop_interactive.py
@@ -1,0 +1,58 @@
+"""
+Interactive chat loop with a scheduled user node.
+
+Each line you type is appended as a user message, then one engine round runs
+to consume that message on the scheduled user turn and produce agent output.
+
+Usage:
+  python user_in_the_loop_interactive.py \
+    --preset src/agentrylab/presets/user_in_the_loop.yaml \
+    --thread chat-1 --user-id user:alice
+
+Type 'quit' or an empty line to exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from agentrylab import init
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Interactive user-in-the-loop demo")
+    ap.add_argument("--preset", default="src/agentrylab/presets/user_in_the_loop.yaml")
+    ap.add_argument("--thread", default="chat-1")
+    ap.add_argument("--user-id", default="user:alice")
+    args = ap.parse_args()
+
+    lab = init(args.preset, experiment_id=args.thread, resume=True)
+
+    print("Interactive chat. Type 'quit' to exit.\n")
+    while True:
+        try:
+            line = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not line or line.lower() in {"quit", "exit"}:
+            break
+
+        # Append and run one round so the scheduled user node consumes it
+        lab.post_user_message(line, user_id=args.user_id)
+        for ev in lab.stream(rounds=1):
+            # Print only fresh events from this round
+            role = ev.get("role")
+            aid = ev.get("agent_id")
+            content: Any = ev.get("content")
+            if isinstance(content, dict):
+                content = str(content)
+            print(f"[{role}] {aid}: {content}")
+
+    print("Bye!")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/user_in_the_loop_quick.py
+++ b/user_in_the_loop_quick.py
@@ -1,0 +1,48 @@
+"""
+Quick demo: scheduled user-in-the-loop.
+
+Usage:
+  python user_in_the_loop_quick.py --message "Hello from Alice!" --rounds 1 \
+    --preset src/agentrylab/presets/user_in_the_loop.yaml --thread demo
+
+Requires: a model provider configured in the preset (e.g., Ollama llama3).
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict
+
+from agentrylab import init
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="User-in-the-loop quick demo")
+    ap.add_argument("--preset", default="src/agentrylab/presets/user_in_the_loop.yaml")
+    ap.add_argument("--thread", default="demo")
+    ap.add_argument("--message", default="Hello from Alice!")
+    ap.add_argument("--user-id", default="user:alice")
+    ap.add_argument("--rounds", type=int, default=1)
+    args = ap.parse_args()
+
+    lab = init(args.preset, experiment_id=args.thread, resume=True)
+
+    # Append a user message for the scheduled user node to consume
+    lab.post_user_message(args.message, user_id=args.user_id)
+
+    # Run N rounds (user turn, then assistant in the preset)
+    lab.run(rounds=args.rounds)
+
+    # Print the last few transcript events
+    for ev in lab.history(limit=10):
+        role = ev.get("role")
+        aid = ev.get("agent_id")
+        content: Any = ev.get("content")
+        if isinstance(content, dict):
+            content = str(content)
+        print(f"[{role}] {aid}: {content}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This PR brings "User in the Loop" end-to-end:

Scope
- PR 1 (baseline injection):
  - State: user input queue + helpers (`enqueue_user_message`, `has_user_input`, `pop_user_input`)
  - Lab API: `post_user_message(content, user_id="user", persist=True)`
  - CLI: `agentrylab say <preset> <thread-id> "message" [--user-id]`
  - Tests: user injection visible to provider on next turn
- PR 2 (scheduled user):
  - Runtime: `UserNode` (scheduled role `user`) + factory mapping
  - Loader schema: allow `role: user` under `agents` (first-class node)
  - Engine: skip empty user outputs (no transcript noise when no input queued)
  - Example preset: `src/agentrylab/presets/user_in_the_loop.yaml`
  - Tests: consumption order, empty-turn skip, no provider call
- PR 3 (docs + examples):
  - README: playful callout + instructions, link to examples
  - Docs: Preset tips, recipes, architecture clarifications, CLI clean-all tips
  - Examples: `user_in_the_loop_quick.py`, `user_in_the_loop_interactive.py`
  - New preset: `solo_chat_user.yaml` (scheduled user turn before assistant)

Why
- Make humans first-class participants: schedule user turns in cadence, or inject messages ad-hoc.
- Keep engine changes minimal and backwards compatible.

How to try
```bash
# Post a message, then consume one round (user -> assistant)
agentrylab say src/agentrylab/presets/user_in_the_loop.yaml demo "Hello!" --user-id user:alice
agentrylab run src/agentrylab/presets/user_in_the_loop.yaml --thread-id demo --resume --max-iters 1

# Or the solo chat variant
agentrylab say src/agentrylab/presets/solo_chat_user.yaml demo "Hi there" --user-id user:you
agentrylab run src/agentrylab/presets/solo_chat_user.yaml --thread-id demo --resume --max-iters 1

# Python examples
python user_in_the_loop_quick.py --message "Hello from Alice!"
python user_in_the_loop_interactive.py --user-id user:alice
```

Testing
- New tests in `tests/test_user_node.py`:
  - queued message precedes agent; agent sees user content in composed messages
  - empty user turn is skipped in transcript
  - UserNode never calls provider
  - multi-user ordering and visibility
- Existing tests pass locally.

BC note
- Existing presets unaffected. `role: user` is additive; engine’s skip rule is limited to user role.

Follow-ups (optional)
- Input-aware scheduler to avoid scheduling user nodes without queued input
- Persist queued inputs across restarts if desirable
